### PR TITLE
Relaxed protege version restriction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,7 +58,7 @@
                         <Bundle-SymbolicName>${project.artifactId};singleton:=true</Bundle-SymbolicName>
                         <Bundle-Vendor>The Protege Development Team</Bundle-Vendor>
                         <Import-Package>
-                            org.protege.editor.owl.*;version="5.0",
+                            org.protege.editor.owl.*;version="[5.0.0,6.0.0)",
                             *
                         </Import-Package>
                         <Include-Resource>plugin.xml, {maven-resources}</Include-Resource>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>de.imise.ontomed</groupId>
     <artifactId>owl2graphml</artifactId>
-    <version>1.0.1</version>
+    <version>1.1.0</version>
     <name>OWL2GraphML</name>
     <description>OWL2GraphML is an API to generate GraphML files from ontologies. It can also be build as Protégé plugin.</description>
 


### PR DESCRIPTION
To use the plugin in Protégé 5.5.0, I relaxed the Felix constraints in the pom.xml.

Tested successfully with Protégé 5.5.0 and yEd 3.20. 